### PR TITLE
update PR and push tekton pipelines for 2.17

### DIFF
--- a/.tekton/vllm-gaudi-217-pull-request.yaml
+++ b/.tekton/vllm-gaudi-217-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "rhoai-2.17"
+      == "null"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: vllm
@@ -28,6 +28,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile.hpu.ubi
+  - name: path-context
+    value: .
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/vllm-gaudi-217-push.yaml
+++ b/.tekton/vllm-gaudi-217-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "rhoai-2.17"
+    build.appstudio.openshift.io/build-nudge-files: "config/base/params-vllm-gaudi.env"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "rhoai-2.16"
+      && ( !".tekton/**".pathChanged() || ".tekton/vllm-gaudi-216-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: vllm
@@ -22,9 +25,28 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhoai-tenant/vllm-gaudi-217:{{revision}}
+    value: quay.io/modh/vllm:{{target_branch}}-gaudi
   - name: dockerfile
     value: Dockerfile.hpu.ubi
+  - name: path-context
+    value: .
+  taskRunSpecs:
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -143,6 +165,10 @@ spec:
         value: $(params.output-image).git
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: fetchTags
+        value: "true"
+      - name: depth
+        value: "2147483647"
       runAfter:
       - init
       taskRef:
@@ -508,6 +534,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - '{{target_branch}}-gaudi-{{revision}}'
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
used the previous 2.16 tekton files as a reference. in particular the push pipeline had several customizations that had to be ported over

